### PR TITLE
Support ADS bibcodes in `Search.setIdentifier`

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -2644,6 +2644,12 @@ Zotero.Translate.Search.prototype.setIdentifier = function (identifier) {
 			arXiv: identifier.arXiv
 		};
 	}
+	else if (identifier.adsBibcode) {
+		search = {
+			itemType: "journalArticle",
+			adsBibcode: identifier.adsBibcode
+		};
+	}
 	else {
 		throw new Error("Unrecognized identifier");
 	}


### PR DESCRIPTION
Moved from zotero/zotero#2128.