### PR TITLE
Support async translators, add async `request` utility

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1858,6 +1858,7 @@ Zotero.Translate.Base.prototype = {
 			this._sandboxManager.sandbox.text = this._text.bind(this);
 			this._sandboxManager.sandbox.innerText = this._innerText.bind(this);
 			this._sandboxManager.sandbox.request = this._sandboxZotero.Utilities.request.bind(this._sandboxZotero.Utilities);
+			this._sandboxManager.sandbox.requestText = this._sandboxZotero.Utilities.requestText.bind(this._sandboxZotero.Utilities);
 			this._sandboxManager.sandbox.requestJSON = this._sandboxZotero.Utilities.requestJSON.bind(this._sandboxZotero.Utilities);
 			this._sandboxManager.sandbox.requestDocument = this._sandboxZotero.Utilities.requestDocument.bind(this._sandboxZotero.Utilities);
 		}

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -278,7 +278,45 @@ Zotero.Utilities.Translate.prototype.processDocuments = async function (urls, pr
 	}
 	
 	translate.decrementAsyncProcesses("Zotero.Utilities.Translate#processDocuments");
-}
+};
+
+Zotero.Utilities.Translate.prototype.request = async function (url, options = {}) {
+	url = this._translate.resolveURL(url);
+
+	let method = options.method || 'GET';
+
+	let internalOptions = {
+		headers: Object.assign({}, this._translate.requestHeaders, options.headers),
+		body: options.body,
+		responseCharset: options.responseCharset,
+		responseType: options.responseType,
+		cookieSandbox: this._translate.cookieSandbox
+	};
+
+	let xhr = await Zotero.HTTP.request(method, url, internalOptions);
+	let status = xhr.status;
+	let headers = {};
+	xhr.getAllResponseHeaders()
+		.trim()
+		.split(/[\r\n]+/)
+		.map(line => line.split(': '))
+		.forEach(parts => headers[parts.shift()] = parts.join(': '));
+	let body = xhr.response;
+
+	return {
+		status,
+		headers,
+		body
+	};
+};
+
+Zotero.Utilities.Translate.prototype.requestJSON = function (url, options = {}) {
+	return this.request(url, { ...options, responseType: 'json' });
+};
+
+Zotero.Utilities.Translate.prototype.requestDocument = function (url, options = {}) {
+	return this.request(url, { ...options, responseType: 'document' });
+};
 
 /**
 * Send an HTTP GET request via XMLHTTPRequest

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -310,12 +310,16 @@ Zotero.Utilities.Translate.prototype.request = async function (url, options = {}
 	};
 };
 
-Zotero.Utilities.Translate.prototype.requestJSON = function (url, options = {}) {
-	return this.request(url, { ...options, responseType: 'json' });
+Zotero.Utilities.Translate.prototype.requestText = async function (url, options = {}) {
+	return (await this.request(url, { ...options, responseType: 'text' })).body;
 };
 
-Zotero.Utilities.Translate.prototype.requestDocument = function (url, options = {}) {
-	return this.request(url, { ...options, responseType: 'document' });
+Zotero.Utilities.Translate.prototype.requestJSON = async function (url, options = {}) {
+	return (await this.request(url, { ...options, responseType: 'json' })).body;
+};
+
+Zotero.Utilities.Translate.prototype.requestDocument = async function (url, options = {}) {
+	return (await this.request(url, { ...options, responseType: 'document' })).body;
 };
 
 /**

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -192,6 +192,8 @@ Zotero.Utilities.Translate.prototype.loadDocument = function(url, succeeded, fai
  * Already documented in Zotero.HTTP, except this optionally takes noCompleteOnError, which prevents
  * the translation process from being cancelled automatically on error, as it is normally. The promise
  * is still rejected on error for handling by the calling function.
+ * @deprecated in Zotero 6.0; prefer requestDocument
+ * @see Zotero.Utilities.Translate#requestDocument
  * @ignore
  */
 Zotero.Utilities.Translate.prototype.processDocuments = async function (urls, processor, noCompleteOnError) {
@@ -358,6 +360,8 @@ Zotero.Utilities.Translate.prototype.requestDocument = async function (url, opti
 /**
 * Send an HTTP GET request via XMLHTTPRequest
 * 
+* @deprecated in Zotero 6.0; prefer request[Text|JSON|Document]
+* @see Zotero.Utilities.Translate#request
 * @param {String|String[]} urls URL(s) to request
 * @param {Function} processor Callback to be executed for each document loaded
 * @param {Function} done Callback to be executed after all documents have been loaded
@@ -418,6 +422,8 @@ Zotero.Utilities.Translate.prototype.doGet = function(urls, processor, done, res
 
 /**
  * Already documented in Zotero.HTTP
+ * @deprecated in Zotero 6.0; prefer request[Text|JSON|Document]
+ * @see Zotero.Utilities.Translate#request
  * @ignore
  */
 Zotero.Utilities.Translate.prototype.doPost = function(url, body, onDone, headers, responseCharset, successCodes) {


### PR DESCRIPTION
Replaces zotero/zotero#1609 based on discussion in that PR's comments.