### PR TITLE
Wrap documents returned by `request`

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -118,6 +118,19 @@ Zotero.HTTP = new function() {
 		return true;	
 	};
 
+	/**
+	 * Return a proxied Document object with a location field, and optionally
+	 * a defaultView field. This method makes an XHR-loaded document resemble
+	 * a document loaded in a browser to ensure compatibility with
+	 * Translate.setTranslator() and other translation methods and translators.
+	 *
+	 * @param {Document} doc
+	 * @param {String} docURL
+	 * @return {Document}
+	 */
+	this.wrapDocument = function (doc, docURL) {
+		throw new Error('Zotero.HTTP.wrapDocument(): not implemented');
+	};
 
 	/**
 	 * Load one or more documents

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -323,6 +323,10 @@ Zotero.Utilities.Translate.prototype.request = async function (url, options = {}
 		.forEach(parts => headers[parts.shift()] = parts.join(': '));
 	let body = xhr.response;
 
+	if (options.responseType === 'document') {
+		body = Zotero.HTTP.wrapDocument(body, xhr.responseURL);
+	}
+
 	return {
 		status,
 		headers,

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -323,7 +323,7 @@ Zotero.Utilities.Translate.prototype.request = async function (url, options = {}
 		.forEach(parts => headers[parts.shift()] = parts.join(': '));
 	let body = xhr.response;
 
-	if (options.responseType === 'document') {
+	if (options.responseType === 'document' && !('location' in body)) {
 		body = Zotero.HTTP.wrapDocument(body, xhr.responseURL);
 	}
 


### PR DESCRIPTION
To mimic the behavior of `processDocuments`.