### PR TITLE
Proxify only web translators

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1773,7 +1773,7 @@ Zotero.Translate.Base.prototype = {
 				this._proxy = translator.proxy;
 			}
 		} else {
-			// Use proxys only for web translators
+			// Use proxy only for web translators
 			this._proxy = null;
 		}
 		this._runningAsyncProcesses = 0;

--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1765,11 +1765,16 @@ Zotero.Translate.Base.prototype = {
 		
 		this._currentTranslator = translator;
 		
-		// Pass on the proxy of the parent translate
-		if (this._parentTranslator) {
-			this._proxy = this._parentTranslator._proxy;
+		if (this.type == 'web') {
+			// Pass on the proxy of the parent translate
+			if (this._parentTranslator) {
+				this._proxy = this._parentTranslator._proxy;
+			} else {
+				this._proxy = translator.proxy;
+			}
 		} else {
-			this._proxy = translator.proxy;
+			// Use proxys only for web translators
+			this._proxy = null;
 		}
 		this._runningAsyncProcesses = 0;
 		this._returnValue = undefined;


### PR DESCRIPTION
Closes https://github.com/zotero/translate/issues/9. I have installed this modification into the Firefox connector (release version 5.0.92) and tested the following:

- various non-proxied URLs (including Springer Link): No regressions
- Springer Link proxied: The issue in https://github.com/zotero/translators/pull/2771 is fixed. No regressions (I tested several examples of type `bookSection` and `multiple` including downloads). 
- Few other proxied URLs: no regressions

Please tell me if there are further tests I could/should do.