### PR TITLE
Improve clarity of translation errors

### DIFF
--- a/src/translation/sandboxManager.js
+++ b/src/translation/sandboxManager.js
@@ -40,8 +40,9 @@ Zotero.Translate.SandboxManager.prototype = {
 	 * @param {String} code Code to evaluate
 	 * @param {String[]} functions Functions to import into the sandbox (rather than leaving
 	 *                                 as inner functions)
+	 * @param {String?} path The source path of the code being evaluated
 	 */
-	eval: function(code, functions) {
+	eval: function(code, functions, path) {
 		// delete functions to import
 		for (var i in functions) {
 			delete this.sandbox[functions[i]];
@@ -61,6 +62,10 @@ Zotero.Translate.SandboxManager.prototype = {
 				code += 'this.sandbox.' + functions[i] + ' = ' + functions[i] + ';';
 			} catch (e) {
 			}
+		}
+
+		if (path) {
+			code += `\n//# sourceURL=${encodeURI(path)}\n`;
 		}
 
 		// Eval in a closure

--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1330,8 +1330,13 @@ Zotero.Translate.Base.prototype = {
 
 			// translate
 			try {
+				let fn = this._sandboxManager.sandbox["do" + this._entryFunctionSuffix];
+				if (!fn) {
+					this.complete(false, new Error(`Translator has no do${this._entryFunctionSuffix} function`));
+				}
+
 				let maybePromise = Function.prototype.apply.call(
-					this._sandboxManager.sandbox["do" + this._entryFunctionSuffix],
+					fn,
 					null,
 					this._getParameters()
 				);
@@ -1694,8 +1699,13 @@ Zotero.Translate.Base.prototype = {
 		
 		this.incrementAsyncProcesses("Zotero.Translate#getTranslators");
 
+		let fn = this._sandboxManager.sandbox["detect" + this._entryFunctionSuffix];
+		if (!fn) {
+			this.complete(false, new Error(`Translator has no detect${this._entryFunctionSuffix} function`));
+		}
+
 		var maybePromise = Function.prototype.apply.call(
-			this._sandboxManager.sandbox["detect" + this._entryFunctionSuffix],
+			fn,
 			null,
 			this._getParameters()
 		);
@@ -1930,7 +1940,11 @@ Zotero.Translate.Base.prototype = {
 	_generateErrorString: function (error) {
 		var errorString = error;
 		if (error.stack && error) {
-			errorString += "\n\n" + error.stack;
+			let stack = error.stack;
+			if (Zotero.isFx) {
+				stack = Zotero.Debug.filterStack(stack);
+			}
+			errorString += "\n\n" + stack;
 		}
 		if (this.path) {
 			errorString += `\nurl => ${this.path}`;


### PR DESCRIPTION
- Include translator labels in stack traces instead of "eval"
    - These have to be valid URIs, so some errors will include `%20`s
- Clean Bluebird lines from stack traces in the client
- Throw clear error when a detect* or do* function is missing

Fixes zotero/zotero#2072