### PR TITLE
Complete with error when initial translator `eval()` fails

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1786,7 +1786,8 @@ Zotero.Translate.Base.prototype = {
 				);
 			}
 			catch (e) {
-				Zotero.logError(e);
+				this.complete(false, e);
+				return;
 			}
 			this._translatorInfo = this._sandboxManager.sandbox.ZOTERO_TRANSLATOR_INFO;
 		}.bind(this);


### PR DESCRIPTION
This catches syntax errors and errors thrown by top-level code and immediately fails translation instead of just logging the error and continuing, which will inevitably result in a `Translator has no [...] function` error being thrown later. Completing with an error also allows Scaffold to display the error in its output log, whereas `Zotero.logError()` only puts its output in the debug console/stderr.