### PR TITLE
Translator tester: Be more vigilant against empty test cases.

### DIFF
--- a/testTranslators/translatorTester.js
+++ b/testTranslators/translatorTester.js
@@ -224,8 +224,12 @@ var Zotero_TranslatorTester = function(translator, type, debugCallback, translat
 	var testEnd   = code.indexOf("/** END TEST CASES **/"); 
 	if (testStart !== -1 && testEnd !== -1) {
 		var test = code.substring(testStart + 24, testEnd)
+			.trim()
 			.replace(/^[\s\r\n]*var testCases = /, '')
 			.replace(/;[\s\r\n]*$/, '');
+		if (!test) {
+			test = "[]";
+		}
 		try {
 			var testObject = JSON.parse(test);
 		} catch (e) {


### PR DESCRIPTION
The test cases in a translator script may be empty, not just with an empty array for `var testCases`, but in the sense of completely missing.

In that case, don't pass invalid JSON (all whitespaces or empty string) to `JSON.parse()`, and use an empty array instead.

This fixes an annoying `SyntaxError` in the console while loading the file `Ovid.js` in the translators repository. That translator should be fixed, too.