### PR TITLE
Fix race condition caused by `complete()` in _loadTranslator > parse

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1788,22 +1788,16 @@ Zotero.Translate.Base.prototype = {
 		var parse = function(code) {
 			Zotero.debug("Translate: Parsing code for " + translator.label + " "
 				+ "(" + translator.translatorID + ", " + translator.lastUpdated + ")", 4);
-			try {
-				this._sandboxManager.eval(
-					"var exports = {}, ZOTERO_TRANSLATOR_INFO = " + code,
-					[
-						"detect" + this._entryFunctionSuffix,
-						"do" + this._entryFunctionSuffix,
-						"exports",
-						"ZOTERO_TRANSLATOR_INFO"
-					],
-					(translator.file ? translator.file.path : translator.label)
-				);
-			}
-			catch (e) {
-				this.complete(false, e);
-				return;
-			}
+			this._sandboxManager.eval(
+				"var exports = {}, ZOTERO_TRANSLATOR_INFO = " + code,
+				[
+					"detect" + this._entryFunctionSuffix,
+					"do" + this._entryFunctionSuffix,
+					"exports",
+					"ZOTERO_TRANSLATOR_INFO"
+				],
+				(translator.file ? translator.file.path : translator.label)
+			);
 			this._translatorInfo = this._sandboxManager.sandbox.ZOTERO_TRANSLATOR_INFO;
 		}.bind(this);
 		


### PR DESCRIPTION
In 81991533dd3531acb9bfd6bb9457136a0af75f0f, I fixed an issue that was particularly noticeable (and confusing) in Scaffold: when a translator's top-level code threw an error or failed to parse, the error would be swallowed and translation would continue. It would *usually* fail later because the `detect` and `do` methods wouldn't have been defined, but not always: if enough of the translator's code evaluated successfully before the error was thrown, it's possible that its `detect`/`do` methods could've run, and their behavior would've been undefined. I fixed that by immediately calling `this.complete(false)` in the catch block and returning.

That caused some kind of race condition. The next translator would get loaded while the previous one was still being evaluated; the `translator` local in `_loadTranslator()` was no longer equal to `this._currentTranslator` by the time `parse()` got called. I think it had to do with `decrementAsyncProcesses()` calling `complete()` when all async processes finish, or `complete()` being responsible for calling `_detect()` again but not being able to await it. I don't really know. But removing the try-catch block entirely and letting the exception propagate accomplishes the same thing - translation fails immediately if there's an error during the initial eval - without causing a race condition.

Fixes zotero/zotero#3203.