### PR TITLE
Support async itemDone on child translator

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -180,7 +180,10 @@ Zotero.Translate.Sandbox = {
 				// just return the item array
 				if(translate._libraryID === false || translate._parentTranslator) {
 					translate.newItems.push(item);
-					return translate._runHandler("itemDone", item, item);
+					translate.incrementAsyncProcesses('itemDone');
+					let result = await translate._runHandler("itemDone", item, item);
+					translate.decrementAsyncProcesses('itemDone');
+					return result;
 				}
 				
 				// We use this within the connector to keep track of items as they are saved
@@ -336,7 +339,13 @@ Zotero.Translate.Sandbox = {
 							if(arg1 == "itemDone") {
 								item.complete = translate._sandboxZotero.Item.prototype.complete;
 							}
-							arg2(obj, item);
+							let result = arg2(obj, item);
+							if (result && result.then && result.catch) {
+								return result.catch(() => {
+									translate.complete(false, e);
+								});
+							}
+							return result;
 						} catch(e) {
 							translate.complete(false, e);
 						}


### PR DESCRIPTION
@zoe-translates pointed out that you can't set an async `itemDone` handler on a child translator, like

```js
let translate = Zotero.loadTranslator('web');
translate.setTranslator('...');
translate.setHandler('itemDone', (obj, item) => {
	let abstractNote = (await requestJSON('https://...')).description;
	item.abstractNote = abstractNote;
	item.complete();
}
await translate.translate();
```

Instead, that code will cause translation to fail (no items returned) when it awaits the HTTP request.

It looks like we already support async handlers (in most cases, at least!). We just weren't awaiting handlers set on child `safeTranslator`s, nor were we incrementing/decrementing async processes in order to wait for the `itemDone` handler to complete when the child translator doesn't await `Item#complete()`. This PR fixes those two issues. Client translation tests are passing.