### PR TITLE
Add `Item#setExtra()` and refactor sandbox Item/Collection constructors

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -1950,7 +1950,15 @@ Zotero.Translate.Base.prototype = {
 			}
 
 			setExtra(field, value) {
-				this.extra = (this.extra ? this.extra + '\n' : '') + `${field}: ${value}`;
+				let lines = String(this.extra || '').split('\n');
+				let existingIndex = lines.findIndex(line => line.startsWith(field + ': '));
+				if (existingIndex !== -1) {
+					lines[existingIndex] = `${field}: ${value}`;
+				}
+				else {
+					lines.push(`${field}: ${value}`);
+				}
+				this.extra = lines.join('\n');
 			}
 
 			complete() {


### PR DESCRIPTION
We now use classes for Item and Collection. No more eval when creating the sandbox!

No need to manually strip the `complete` property anymore - it's now set as non-enumerable when cloned and is non-enumerable by default as a class method.

Closes #32