### PR TITLE
Improve the compatibility of `setExtra`

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -95,6 +95,7 @@ Zotero.Translate.Sandbox = {
 				}
 					
 				const allowedObjects = [
+					"setExtra",
 					"complete",
 					"attachments",
 					"creators",
@@ -333,6 +334,14 @@ Zotero.Translate.Sandbox = {
 						try {
 							item = item.wrappedJSObject ? item.wrappedJSObject : item;
 							if(arg1 == "itemDone") {
+								Object.defineProperty(
+									item,
+									"setExtra",
+									{
+										value: translate._sandboxZotero.Item.prototype.setExtra,
+										enumerable: false,
+									}
+								);
 								Object.defineProperty(
 									item,
 									"complete",
@@ -1977,12 +1986,26 @@ Zotero.Translate.Base.prototype = {
 
 			setExtra(field, value) {
 				let lines = String(this.extra || '').split('\n');
-				let existingIndex = lines.findIndex(line => line.startsWith(field + ': '));
-				if (existingIndex !== -1) {
-					lines[existingIndex] = `${field}: ${value}`;
+				let kebabField = field.replace(/(\s?[A-Z])/g, (_, char) => `-${char.toLowerCase()}`).replace(/_/g, '-').replace(/^-/, '');
+				let kebabTxtFields = Object.keys(Zotero.Schema.CSL_DATE_MAPPINGS).map(textField => textField.replace(/_/g, '-'))
+				let kebabDateFields = Object.keys(Zotero.Schema.CSL_TEXT_MAPPINGS).map(textField => textField.replace(/_/g, '-'))
+				let cslNames = Object.keys(Zotero.Schema.CSL_NAME_MAPPINGS);
+				if (cslNames.includes(kebabField)) {
+					lines.unshift(`${field}: ${value}`);
 				}
 				else {
-					lines.push(`${field}: ${value}`);
+					let existingIndex = lines.findIndex(line => line.startsWith(field + ': '));
+					if (existingIndex !== -1) {
+						lines[existingIndex] = `${field}: ${value}`;
+					}
+					else {
+						if (kebabTxtFields.includes(kebabField) || kebabDateFields.includes(kebabField)) {
+							lines.unshift(`${field}: ${value}`);
+						}
+						else {
+							lines.push(`${field}: ${value}`);
+						}
+					}
 				}
 				this.extra = lines.join('\n');
 			}


### PR DESCRIPTION
This is a change submitted to advance [zotero/translators#PR3417](https://github.com/zotero/translators/pull/3417#discussion_r1948134668), and has not been tested locally, but it should be working well.

- Support calling `Zotero.Translate.Base.Item.setExtra` in `itemDone` handler
- Allow setting multiple CSL name variables with the same field name via `setExtra`