### PR TITLE
Fix typo (and formatting) in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zotero Translate
 
-This repository contains the Zotero translation architecture code responsible for 
+This repository contains the Zotero translation architecture code responsible for
 parsing Zotero translators and running them on live and static web pages to retrieve
 Zotero items.
 
@@ -11,10 +11,11 @@ A consumer of this repository needs to implement the following interfaces:
 - `Zotero.Translate.ItemSaver` found in `translation/translate_item.js`
 
 You also need to:
+
 - Call `Zotero.Schema.init(data)` with Zotero `schema.json`.
 - Call `Zotero.Date.init(json)` with the JSON from `utilities/resource/dateFormats.json`
 - If running in a ModuleJS environment (e.g. Node.js) call `require('../utilities/cachedTypes').setTypeSchema(typeSchema)`
-with the result of `utilities/resource/zoteroTypeSchemaData.js`.
+  with the result of `utilities/resource/zoteroTypeSchemaData.js`.
 
 Please bundle translators and Zotero schema with the translation architecture.
 Do not load them from a remote server.
@@ -23,18 +24,19 @@ You may also want to reimplement or modify:
 
 - `Zotero.Repo` found in `repo.js` to set up periodic translator update retrieval
 - `Zotero.Debug` found in `debug.js` to customize debug logging
-- `Zotero` and `Zotero.Prefs` found in `zotero.js` to set up the environment and 
-long-term preference storage
+- `Zotero` and `Zotero.Prefs` found in `zotero.js` to set up the environment and
+  long-term preference storage
 - `Zotero.Translate.ItemGetter` found in `translation/translate_item.js` for export
-translation
+  translation
 - `Zotero.Translate.SandboxManager` found in `translation/sandboxManager.js` for
-a tighter Sandbox environment if available on your the platform
+  a tighter Sandbox environment if available on your platform
 
 ### Example
 
 See `example/index.html` for file loading order.
 
-To run the example: 
+To run the example:
+
 ```bash
 $ git submodule update --init
 $ google-chrome --disable-web-security --user-data-dir=/tmp/chromeTemvar


### PR DESCRIPTION
Fix a small typo ("available on your _the_ platform") in the readme, and run a markdown formatter on it for consistency.