### PR TITLE
Update module export checks to use 'module.exports' for bundler compatibility

### DIFF
--- a/src/debug.js
+++ b/src/debug.js
@@ -190,6 +190,6 @@ Zotero.Debug = new function () {
 	};
 };
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = Zotero.Debug;
 }

--- a/src/http.js
+++ b/src/http.js
@@ -153,6 +153,6 @@ Zotero.HTTP = new function() {
 	};
 };
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = Zotero.HTTP;
 }

--- a/src/promise.js
+++ b/src/promise.js
@@ -68,6 +68,6 @@ Zotero.Promise.delay = function (timeout) {
 	});
 }
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = Zotero.Promise;
 }

--- a/src/proxy.js
+++ b/src/proxy.js
@@ -343,7 +343,7 @@ Zotero.Proxy.prototype.toDisplayName = function () {
 	}
 }
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = { Proxy: Zotero.Proxy, Proxies: Zotero.Proxies };
 }
 

--- a/src/rdf/identity.js
+++ b/src/rdf/identity.js
@@ -15,7 +15,7 @@
 /*jsl:option explicit*/
 // Turn on JavaScriptLint variable declaration checking
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   this.$rdf = require('./init');
 }
 
@@ -498,6 +498,6 @@ We replace the bigger with the smaller.
 
 }();
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   module.exports = $rdf.IndexedFormula;
 }

--- a/src/rdf/init.js
+++ b/src/rdf/init.js
@@ -37,7 +37,11 @@ var $rdf = {
 	log: Zotero.debug
 };
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof globalThis !== 'undefined') {
+	globalThis.$rdf = $rdf;
+}
+
+if (typeof module === 'object' && module.exports) {
 	module.exports = $rdf;
 	$rdf.Util = require('./uri');
 	$rdf = Object.assign($rdf, require('./term'));

--- a/src/rdf/n3parser.js
+++ b/src/rdf/n3parser.js
@@ -1,4 +1,4 @@
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   var $rdf = require('./init');
 }
 
@@ -1387,6 +1387,6 @@ the module, including tests and test harness.
 
 }();
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   module.exports = $rdf.N3Parser;
 }

--- a/src/rdf/rdfparser.js
+++ b/src/rdf/rdfparser.js
@@ -53,7 +53,7 @@
  * holders.
  */
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   var $rdf = require('./init');
 }
  
@@ -573,6 +573,6 @@ $rdf.RDFParser = function (store) {
   }
 }
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   module.exports = $rdf.RDFParser;
 }

--- a/src/rdf/serialize.js
+++ b/src/rdf/serialize.js
@@ -9,7 +9,7 @@
 // @@@ Check the whole toStr thing tosee whetehr it still makes sense -- tbl
 // 
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   var $rdf = require('./init');
 }
 
@@ -881,6 +881,6 @@ __Serializer.prototype.statementsToXML = function (sts) {
 
 }();
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   module.exports = $rdf.Serializer;
 }

--- a/src/rdf/term.js
+++ b/src/rdf/term.js
@@ -11,7 +11,7 @@
 
 (function() {
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   this.$rdf = require('./init');
 }
 
@@ -515,7 +515,7 @@ Term.Formula.prototype.whether = function (s, p, o, w) {
   return this.statementsMatching(s, p, o, w, false).length;
 }
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   module.exports = Term;
 }
 else {

--- a/src/rdf/uri.js
+++ b/src/rdf/uri.js
@@ -12,7 +12,7 @@
 //  See also http://www.w3.org/2000/10/swap/uripath.py
 //
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   var $rdf = require('./init');
 }
 
@@ -142,6 +142,6 @@ $rdf.Util.uri.protocol = function (uri) {
 } //protocol
 //ends
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
   module.exports = $rdf.Util;
 }

--- a/src/tlds.js
+++ b/src/tlds.js
@@ -269,6 +269,11 @@ const TLDS = {
 	"zm":true,
 	"zw":true
 };
-if (typeof process === 'object' && process + '' === '[object process]'){
+
+if (typeof globalThis !== 'undefined') {
+	globalThis.TLDS = TLDS;
+}
+
+if (typeof module === 'object' && module.exports) {
     module.exports = TLDS;
 }

--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -3305,6 +3305,6 @@ Zotero.Translate.IO._RDFSandbox.prototype = {
 	}
 };
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
     module.exports = Zotero.Translate;
 }

--- a/src/translator.js
+++ b/src/translator.js
@@ -190,6 +190,6 @@ Zotero.Translator.TRANSLATOR_OPTIONAL_PROPERTIES = TRANSLATOR_OPTIONAL_PROPERTIE
 Zotero.Translator.TRANSLATOR_PASSING_PROPERTIES = TRANSLATOR_PASSING_PROPERTIES;
 Zotero.Translator.TRANSLATOR_CACHING_PROPERTIES = TRANSLATOR_CACHING_PROPERTIES;
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = Zotero.Translator;
 }

--- a/src/translators.js
+++ b/src/translators.js
@@ -169,6 +169,6 @@ Zotero.Translators.CodeGetter.prototype.getAll = async function () {
 	return Promise.all(codes);
 };
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = Zotero.Translators;
 }

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -492,6 +492,6 @@ for(var j in Zotero.Utilities.Translate.prototype) {
 	}
 }
 
-if (typeof process === 'object' && process + '' === '[object process]'){
+if (typeof module === 'object' && module.exports) {
 	module.exports = Zotero.Utilities.Translate;
 }

--- a/src/zotero.js
+++ b/src/zotero.js
@@ -92,3 +92,12 @@ Zotero.Prefs = new function(){
 		delete tempStore[pref];
 	}
 }
+
+if (typeof globalThis !== 'undefined') {
+	globalThis.Zotero = Zotero;
+	globalThis.ZOTERO_CONFIG = ZOTERO_CONFIG;
+}
+
+if (typeof module === 'object' && module.exports) {
+	module.exports = Zotero;
+}


### PR DESCRIPTION
Currently, the module exports use `process` to detect if they are run in a Node context. Some bundler (in esm mode) don't expose the process interface but still allow commonjs style exports by polyfilling (or transpiling) `module.exports`. Thus, here we change the detection to use `module` over `process`. Moreover, add a few missing assignments to `globalThis`.

This is also closer to the UMD standard and what is used in other Zotero repos. 