### PR TITLE
Add support for clearing challenge in browser

### DIFF
--- a/src/translation/translate.js
+++ b/src/translation/translate.js
@@ -2078,8 +2078,9 @@ Zotero.Translate.Base.prototype = {
  * @class Web translation
  *
  * @property {Document} document The document object to be used for web scraping (set with setDocument)
- * @property {Zotero.CookieSandbox} cookieSandbox A CookieSandbox to manage cookies for
- *     this Translate instance.
+ * @property {Number} cookieSandbox An ID from Zotero.HTTP.newCookieContext()
+ *     isolating this Translate instance's cookie jar. This is called
+ *     cookieSandbox for compatibility only.
  */
 Zotero.Translate.Web = function() {
 	this._registeredDOMObservers = {}
@@ -2108,14 +2109,22 @@ Zotero.Translate.Web.prototype.setDocument = function(doc) {
 }
 
 /**
- * Sets a Zotero.CookieSandbox to handle cookie management for XHRs initiated from this
- * translate instance
+ * Set the userContextId used for cookie isolation on XHRs initiated from this
+ * translate instance.
  *
- * @param {Zotero.CookieSandbox} cookieSandbox
+ * @param {number} userContextId An ID from Zotero.HTTP.newCookieContext()
  */
-Zotero.Translate.Web.prototype.setCookieSandbox = function(cookieSandbox) {
-	this.cookieSandbox = cookieSandbox;
-}
+Zotero.Translate.Web.prototype.setUserContextId = function (userContextId) {
+	this.cookieSandbox = userContextId;
+};
+
+/**
+ * @deprecated This method only exists for compatibility. Use {@link #setUserContextId()}.
+ * @param {number} userContextId An ID from Zotero.HTTP.newCookieContext()
+ */
+Zotero.Translate.Web.prototype.setCookieSandbox = function (userContextId) {
+	this.setUserContextId(userContextId);
+};
 
 /**
  * Sets headers to include in HTTP requests. Used by translation-server.
@@ -2699,6 +2708,11 @@ Zotero.Translate.Search.prototype.type = "search";
 Zotero.Translate.Search.prototype._entryFunctionSuffix = "Search";
 Zotero.Translate.Search.prototype.Sandbox = Zotero.Translate.Sandbox._inheritFromBase(Zotero.Translate.Sandbox.Search);
 Zotero.Translate.Search.prototype.ERROR_NO_RESULTS = "No items returned from any translator";
+
+/**
+ * @borrows Zotero.Translate.Web#setUserContextId
+ */
+Zotero.Translate.Search.prototype.setUserContextId = Zotero.Translate.Web.prototype.setUserContextId;
 
 /**
  * @borrows Zotero.Translate.Web#setCookieSandbox

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -450,11 +450,11 @@ Zotero.Utilities.Translate.prototype._tryClearChallengeInBrowser = async functio
 	tried.add(entry.match);
 
 	let challengeURL = entry.getChallengeURL ? entry.getChallengeURL(url) : url;
-	let cookieContextId = this._translate.cookieSandbox ?? undefined;
+	let userContextId = this._translate.cookieSandbox ?? undefined;
 
 	Zotero.debug(`Zotero.Utilities.Translate.request(): Clearing challenge at ${challengeURL} before retrying ${url}`);
 	await Zotero.BrowserRequest.clearChallenge(challengeURL, {
-		cookieContextId,
+		userContextId,
 		entry,
 		allowViewer: true
 	});

--- a/src/utilities_translate.js
+++ b/src/utilities_translate.js
@@ -325,7 +325,28 @@ Zotero.Utilities.Translate.prototype.request = async function (url, options = {}
 
 	// If the request fails or a non-successful status is returned, Zotero.HTTP.request rejects its promise.
 	// We let the Zotero.HTTP.UnexpectedStatusException bubble up to the caller.
-	let xhr = await Zotero.HTTP.request(method, url, internalOptions);
+	let xhr;
+	try {
+		xhr = await Zotero.HTTP.request(method, url, internalOptions);
+		// ...Except when the URL is registered in Zotero.BrowserRequest and the
+		// response looks like a bot challenge, in which case we try to clear
+		// the challenge in a browser and retry.
+		if (this._shouldClearChallengeInBrowser(url, xhr.status, xhr)) {
+			await this._tryClearChallengeInBrowser(url);
+			xhr = await Zotero.HTTP.request(method, url, internalOptions);
+		}
+	}
+	catch (e) {
+		// As above
+		if (e instanceof Zotero.HTTP.UnexpectedStatusException
+				&& this._shouldClearChallengeInBrowser(url, e.status, e.xmlhttp)) {
+			await this._tryClearChallengeInBrowser(url);
+			xhr = await Zotero.HTTP.request(method, url, internalOptions);
+		}
+		else {
+			throw e;
+		}
+	}
 	let status = xhr.status;
 	let responseURL = xhr.responseURL;
 	let headers = {};
@@ -373,6 +394,70 @@ Zotero.Utilities.Translate.prototype.requestJSON = async function (url, options 
  */
 Zotero.Utilities.Translate.prototype.requestDocument = async function (url, options = {}) {
 	return (await this.request(url, { ...options, responseType: 'document' })).body;
+};
+
+/**
+ * Decide whether a response is a bot challenge that we can clear in a browser.
+ * Zotero.BrowserRequest maintains the list of patterns. We only try to clear
+ * a challenge once per origin per Zotero.Translate instance.
+ */
+Zotero.Utilities.Translate.prototype._shouldClearChallengeInBrowser = function (url, status, xhr) {
+	// If we aren't running in the client, there's nothing we can do
+	if (!Zotero.BrowserRequest) return false;
+	
+	let entry = Zotero.BrowserRequest.getEntryForURL(url);
+	if (!entry) return false;
+
+	let tried = this._translate._browserRequestTried ||= new Set();
+	let originKey = entry.match;
+	if (tried.has(originKey)) {
+		return false;
+	}
+
+	if (entry.detectBlock) {
+		let body = '';
+		try {
+			body = xhr?.responseText || '';
+		}
+		catch {
+			let response = xhr?.response;
+			if (response && typeof response !== 'string') {
+				try {
+					body = JSON.stringify(response);
+				}
+				catch {
+					// Ignore
+				}
+			}
+		}
+		return entry.detectBlock(status, body);
+	}
+	return status >= 400;
+};
+
+/**
+ * Clear a bot-detection challenge for the given URL, escalating to a visible
+ * viewer if the site shows a visible captcha. Cookies acquired are put
+ * into the Zotero.Translate instance's cookie context, if it has one.
+ */
+Zotero.Utilities.Translate.prototype._tryClearChallengeInBrowser = async function (url) {
+	if (!Zotero.BrowserRequest) return;
+	
+	let entry = Zotero.BrowserRequest.getEntryForURL(url);
+	if (!entry) return;
+
+	let tried = this._translate._browserRequestTried ||= new Set();
+	tried.add(entry.match);
+
+	let challengeURL = entry.getChallengeURL ? entry.getChallengeURL(url) : url;
+	let cookieContextId = this._translate.cookieSandbox ?? undefined;
+
+	Zotero.debug(`Zotero.Utilities.Translate.request(): Clearing challenge at ${challengeURL} before retrying ${url}`);
+	await Zotero.BrowserRequest.clearChallenge(challengeURL, {
+		cookieContextId,
+		entry,
+		allowViewer: true
+	});
 };
 
 /**

--- a/testTranslators/translatorTester.mjs
+++ b/testTranslators/translatorTester.mjs
@@ -41,7 +41,7 @@ export class TranslatorTester {
 	 * @param {Zotero.Translator} translator
 	 * @param {AbstractWebTranslationEnvironment} [webTranslationEnvironment]
 	 * @param {Zotero.Translators} [translatorProvider]
-	 * @param {Zotero.CookieSandbox} [cookieSandbox]
+	 * @param {number} [cookieSandbox] userContextId from Zotero.HTTP.newCookieContext()
 	 * @param {(message: any) => void} [debug]
 	 */
 	constructor(translator, {


### PR DESCRIPTION
When running in the client.

And update methods to add `setUserContextId()` alias and clarify that `cookieSandbox` has been replaced.